### PR TITLE
Upgrade project to bpmn-js v0.11.0

### DIFF
--- a/lib/features/rules/SpartaRules.js
+++ b/lib/features/rules/SpartaRules.js
@@ -20,14 +20,14 @@ SpartaRules.$inject = ['eventBus'];
 SpartaRules.prototype.init = function() {
 
     this.addRule('shape.create', function(context) {
-        var target = context.parent;
+        var target = context.target;
         var shape = context.shape;
 
         return canCreate(shape, target);
     });
 
     //connections can only be reconnected to the original connection source/target.
-    //this allows users to move the position of a connection around the original source/targets 
+    //this allows users to move the position of a connection around the original source/targets
     //for aesthetic purposes without breaking the process
     this.addRule('connection.reconnectStart', function(context) {
         var target = context.hover;
@@ -43,8 +43,8 @@ SpartaRules.prototype.init = function() {
     });
 };
 
-//allow NOTHING to be dropped unless the attribute on the 
-//target, "ssi:allowDrop", is defined and the shape's type 
+//allow NOTHING to be dropped unless the attribute on the
+//target, "ssi:allowDrop", is defined and the shape's type
 //matches the attribute value.
 function canCreate(shape, target) {
     var allowDrop = target.businessObject.get('ssi:allowDrop');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sparta-bpmn-js",
     "version": "0.1.0",
-  "description": "Sparta BPMN Web Modeler",
+    "description": "Sparta BPMN Web Modeler",
     "scripts": {
         "test": "grunt test"
     },
@@ -17,6 +17,7 @@
     "devDependencies": {
         "browserify": "^8.1.0",
         "browserify-derequire": "^0.9.1",
+        "chai": "^3.2.0",
         "bundle-collapser": "^1.1.1",
         "grunt": "^0.4.4",
         "grunt-contrib-copy": "^0.7.0",
@@ -24,17 +25,20 @@
         "grunt-jsdoc": "^0.5.1",
         "grunt-karma": "^0.8.0",
         "grunt-release": "^0.7.0",
-        "jasmine-test-container-support": "^0.1.2",
+        "mocha-test-container-support": "^0.2.0",
         "jsondiffpatch": "^0.1.26",
         "karma": "^0.12.12",
         "karma-browserify": "^4.0.0",
+        "karma-chai": "^0.1.0",
         "karma-chrome-launcher": "^0.1.2",
         "karma-firefox-launcher": "^0.1.3",
         "karma-ie-launcher": "^0.1.4",
-        "karma-jasmine": "https://github.com/Nikku/karma-jasmine/archive/jasmine-v2.0.0-latest-1.tar.gz",
+        "karma-mocha": "^0.2.0",
         "karma-phantomjs-launcher": "^0.1.2",
         "karma-safari-launcher": "^0.1.1",
         "load-grunt-tasks": "^0.3.0",
+        "mocha": "^2.3.2",
+        "mocha-test-container-support": "^0.2.0",
         "source-map-concat": "^0.4.0",
         "stringify": "^3.1.0",
         "time-grunt": "^0.3.2",
@@ -42,10 +46,10 @@
         "grunt-exec": "~0.4.6"
     },
     "dependencies": {
-        "bpmn-js": "^0.10.3",
+        "bpmn-js": "^0.11.0",
         "bpmn-moddle": "^0.8.3",
-        "diagram-js": "^0.10.2",
-        "diagram-js-direct-editing": "^0.10.0",
+        "diagram-js": "^0.11.0",
+        "diagram-js-direct-editing": "^0.11.0",
         "didi": "^0.0.4",
         "ids": "^0.1.0",
         "inherits": "^2.0.1",

--- a/test/config/karma.unit.js
+++ b/test/config/karma.unit.js
@@ -5,7 +5,7 @@ module.exports = function(karma) {
 
     basePath: '../../',
 
-    frameworks: [ 'browserify', 'jasmine' ],
+    frameworks: [ 'browserify', 'mocha', 'chai' ],
 
     files: [
       'test/spec/**/*Spec.js'

--- a/test/fixtures/bpmn/SpartaRules.bpmn
+++ b/test/fixtures/bpmn/SpartaRules.bpmn
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://activiti.org/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:ssi="http://www.spartasystems.com/bpmn2" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_oQldgJhiEeSQ552e2GAF4A" exporter="camunda modeler" exporterVersion="2.6.0" targetNamespace="http://activiti.org/bpmn">
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:ssi="http://www.spartasystems.com/bpmn2" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_oQldgJhiEeSQ552e2GAF4A" targetNamespace="http://activiti.org/bpmn" exporter="camunda modeler" exporterVersion="2.6.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
   <bpmn2:collaboration id="_Collaboration_3">
-    <bpmn2:participant id="TEST_PROCESS" name="TEST_PROCESS" processRef="TEST_PROCESS-1"/>
+    <bpmn2:participant id="TEST_PROCESS" name="TEST_PROCESS" processRef="TEST_PROCESS-1" />
   </bpmn2:collaboration>
   <bpmn2:process id="TEST_PROCESS-1" name="TEST_PROCESS" isExecutable="true">
+    <bpmn2:startEvent id="CreateComplaint" name="Start">
+      <bpmn2:outgoing>SequenceFlow_15</bpmn2:outgoing>
+    </bpmn2:startEvent>
     <bpmn2:userTask id="ReviewComplaint" name="Review">
       <bpmn2:incoming>SequenceFlow_15</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
     </bpmn2:userTask>
-    <bpmn2:sequenceFlow id="SequenceFlow_3" name="" sourceRef="ReviewComplaint" targetRef="DistributeAcknowledge"/>
     <bpmn2:serviceTask id="DistributeAcknowledge" name="Acknowledge">
       <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
     </bpmn2:serviceTask>
-    <bpmn2:sequenceFlow id="SequenceFlow_2" ssi:allowDrop="bpmn:CallActivity" name="" sourceRef="DistributeAcknowledge" targetRef="SubmitRCA"/>
     <bpmn2:userTask id="SubmitRCA" name="Submit RCA">
       <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
@@ -21,66 +22,63 @@
     <bpmn2:endEvent id="Closed-NoCAPA" name="End">
       <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
     </bpmn2:endEvent>
-    <bpmn2:startEvent id="CreateComplaint" name="Start">
-      <bpmn2:outgoing>SequenceFlow_15</bpmn2:outgoing>
-    </bpmn2:startEvent>
-    <bpmn2:sequenceFlow id="SequenceFlow_15" name="" sourceRef="CreateComplaint" targetRef="ReviewComplaint"/>
-    <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="SubmitRCA" targetRef="Closed-NoCAPA"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_15" name="" sourceRef="CreateComplaint" targetRef="ReviewComplaint" />
+    <bpmn2:sequenceFlow id="SequenceFlow_3" name="" sourceRef="ReviewComplaint" targetRef="DistributeAcknowledge" />
+    <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="DistributeAcknowledge" targetRef="SubmitRCA" ssi:allowDrop="bpmn:CallActivity" />
+    <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="SubmitRCA" targetRef="Closed-NoCAPA" />
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="_Collaboration_3">
       <bpmndi:BPMNShape id="_BPMNShape_Participant_5" bpmnElement="TEST_PROCESS" isHorizontal="true">
-        <dc:Bounds height="373.0" width="1549.0" x="0.0" y="0.0"/>
+        <dc:Bounds x="96" y="119" width="1156" height="276" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_6" bpmnElement="CreateComplaint">
-        <dc:Bounds height="36.0" width="36.0" x="204.0" y="35.0"/>
+        <dc:Bounds x="201" y="273" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="22.0" width="34.0" x="205.0" y="13.0"/>
+          <dc:Bounds x="174" y="251" width="90" height="22" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_UserTask_57" bpmnElement="ReviewComplaint">
-        <dc:Bounds height="80.0" width="100.0" x="168.0" y="191.0"/>
+        <dc:Bounds x="302" y="251" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_ServiceTask_5" bpmnElement="DistributeAcknowledge">
-        <dc:Bounds height="80.0" width="100.0" x="648.0" y="191.0"/>
+        <dc:Bounds x="645" y="251" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_UserTask_60" bpmnElement="SubmitRCA">
-        <dc:Bounds height="80.0" width="100.0" x="1068.0" y="191.0"/>
+        <dc:Bounds x="968" y="251" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_30" bpmnElement="Closed-NoCAPA">
-        <dc:Bounds height="36.0" width="36.0" x="1476.0" y="213.0"/>
+        <dc:Bounds x="1145" y="273" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="22.0" width="29.0" x="1480.0" y="255.0"/>
+          <dc:Bounds x="1119" y="315" width="90" height="22" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_27" bpmnElement="SequenceFlow_15" sourceElement="_BPMNShape_StartEvent_6" targetElement="_BPMNShape_UserTask_57">
-        <di:waypoint xsi:type="dc:Point" x="222.0" y="71.0"/>
-        <di:waypoint xsi:type="dc:Point" x="222.0" y="126.0"/>
-        <di:waypoint xsi:type="dc:Point" x="218.0" y="126.0"/>
-        <di:waypoint xsi:type="dc:Point" x="218.0" y="191.0"/>
+        <di:waypoint xsi:type="dc:Point" x="237" y="291" />
+        <di:waypoint xsi:type="dc:Point" x="302" y="291" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="215.0" y="161.0"/>
+          <dc:Bounds x="269" y="221" width="90" height="6" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="_BPMNShape_UserTask_57" targetElement="_BPMNShape_ServiceTask_5">
-        <di:waypoint xsi:type="dc:Point" x="268.0" y="231.0"/>
-        <di:waypoint xsi:type="dc:Point" x="648.0" y="231.0"/>
+        <di:waypoint xsi:type="dc:Point" x="402" y="291" />
+        <di:waypoint xsi:type="dc:Point" x="645" y="291" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="293.0" y="231.0"/>
+          <dc:Bounds x="347" y="291" width="90" height="6" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_BPMNShape_ServiceTask_5" targetElement="_BPMNShape_UserTask_60">
-        <di:waypoint xsi:type="dc:Point" x="748.0" y="231.0"/>
-        <di:waypoint xsi:type="dc:Point" x="1068.0" y="231.0"/>
+        <di:waypoint xsi:type="dc:Point" x="745" y="291" />
+        <di:waypoint xsi:type="dc:Point" x="968" y="291" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="797.0" y="231.0"/>
+          <dc:Bounds x="851" y="291" width="90" height="6" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_UserTask_60" targetElement="_BPMNShape_EndEvent_30">
-        <di:waypoint xsi:type="dc:Point" x="1168.0" y="231.0"/>
-        <di:waypoint xsi:type="dc:Point" x="1476.0" y="231.0"/>
+        <di:waypoint xsi:type="dc:Point" x="1068" y="291" />
+        <di:waypoint xsi:type="dc:Point" x="1145" y="291" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="1327.0" y="231.0"/>
+          <dc:Bounds x="1381" y="291" width="90" height="6" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -2,6 +2,8 @@
 
 require('bpmn-js/test/TestHelper');
 
+var TestContainer = require('mocha-test-container-support');
+
 var SpartaModeler = require('../../lib/SpartaModeler');
 
 
@@ -10,7 +12,7 @@ describe('SpartaModeler', function() {
     var container;
 
     beforeEach(function() {
-        container = jasmine.getEnv().getTestContainer();
+        container = TestContainer.get(this);
     });
 
 
@@ -25,7 +27,7 @@ describe('SpartaModeler', function() {
     }
 
 
-    iit('test', function(done) {
+    it.only('test', function(done) {
         var xml = require('../fixtures/bpmn/SpartaRules.bpmn');
         createModeler(xml, done);
     });

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -2,6 +2,8 @@
 
 require('bpmn-js/test/TestHelper');
 
+var TestContainer = require('mocha-test-container-support');
+
 /* global bootstrapViewer, inject */
 
 var contextPadModule = require('../../../../lib/features/context-pad'),
@@ -32,7 +34,7 @@ describe('features - context-pad', function() {
 
         var container;
         beforeEach(function() {
-            container = jasmine.getEnv().getTestContainer();
+            container = TestContainer.get(this);
         });
 
         it('should not display delete button for "locked-down" items ',

--- a/test/spec/features/modeling/behavior/RemoveDroppableBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/RemoveDroppableBehaviorSpec.js
@@ -2,6 +2,8 @@
 
 var TestHelper = require('bpmn-js/test/TestHelper');
 
+var TestContainer = require('mocha-test-container-support');
+
 var domQuery = require('min-dom/lib/query');
 
 /* global bootstrapViewer, inject */
@@ -33,7 +35,7 @@ describe('features/modeling/behavior - Remove Call Activity', function() {
 
     var container;
     beforeEach(function() {
-      container = jasmine.getEnv().getTestContainer();
+      container = TestContainer.get(this);
     });
 
     it('CallActivity\'s source and target element should automatically reconnect',


### PR DESCRIPTION
This upgrades the example to the bpmn-js v0.11.0 stable release and allows users to try it out without further linking or other magic.
